### PR TITLE
Updated ETC Cooperative website "people" page and "contact" page

### DIFF
--- a/src/content/pages/contact/contact.mdx
+++ b/src/content/pages/contact/contact.mdx
@@ -9,13 +9,12 @@ How to stay in contact with the ETC Cooperative:
 
 - Email
     - bob@etccooperative.org
-    - yaz@etccooperative.org
+    - kevin@etccooperative.org
     - alison@etccooperative.org
 - Twitter
     - [@ETCCooperative](https://twitter.com/ETCCooperative)
     - [@bobsummerwill](https://twitter.com/bobsummerwill)
-    - [@Yazanator](https://twitter.com/Yazanator)
+    - [@Classic\_Kevin\_](https://twitter.com/Classic_Kevin_)
     - [@aalexis1234](https://twitter.com/aalexis1234)
 
-Or on the [ETC Discord](https://discord.gg/HgBa9b4) instance or
-[ETC Global Comms](https://bobsummerwill.com/2019/10/03/addressing-east-west-disconnect-in-etc/") WeChat channel.
+Or on the [ETC Discord](https://discord.gg/HgBa9b4).

--- a/src/content/pages/people/people.mdx
+++ b/src/content/pages/people/people.mdx
@@ -21,15 +21,6 @@ Bob has made a [public and ongoing full disclosure](https://bobsummerwill.com/co
 relationships, to avoid any possible future accusation of conflict of interests or
 unethical financial conduct.
 
-![Stev](/stev_headshot.jpg)
-
-**Stevan Lohja (Director of Developer Relations)** – Stevan Lohja is an active
-member of the Ethereum Classic project, previously contributing to Ethereum
-Classic under ETCDEV, ETC Labs, and ETC Core. Stevan is a strong advocate for
-the Ethereum Classic project producing a plethora of technical content to
-engage the community and played a significant role in core infrastructure
-Ethereum Classic projects for the past few years.
-
 ![Kevin](/kevin_lord_headshot.jpg)
 
 **Kevin Lord (Community Manager)** – Kevin Lord has over 5 years of experience


### PR DESCRIPTION
Updated ETC Cooperative website "people" page and "contact" page to reflect staffing changes since the website was first constructed.