### PR TITLE
Rivet post typo "Etherecluster" to "Ethercluster".

### DIFF
--- a/src/content/posts/2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-cn/2023-01-02-index.cn.md
+++ b/src/content/posts/2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-cn/2023-01-02-index.cn.md
@@ -15,7 +15,7 @@ tags: [announcements]
 
 ## IMPORTANT ANNOUNCEMENT:
 
-The ETC Cooperative is changing the RPC URL for the Ethereum Classic mainnet from Etherecluster to Rivet.
+The ETC Cooperative is changing the RPC URL for the Ethereum Classic mainnet from Ethercluster to Rivet.
 
 This is important information for wallet operators, exchanges, mining pools, dapps or any other Ethereum Classic service or application who uses Ethercluster as an endpoint to send transactions and query the mainnet.
 

--- a/src/content/posts/2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-cn/2023-01-02-index.cn.md
+++ b/src/content/posts/2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-cn/2023-01-02-index.cn.md
@@ -1,5 +1,5 @@
 ---
-id: "2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-en"
+id: "2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-cn"
 title: "The Ethereum Classic RPC URL Is Changing From Ethercluster to Rivet"
 author: Donald McIntyre
 featuredImage: rivet-article-banner.png

--- a/src/content/posts/2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-en/2023-01-02-index.en.md
+++ b/src/content/posts/2023-01-02-the-ethereum-classic-rpc-url-is-changing-from-ethercluster-to-rivet-en/2023-01-02-index.en.md
@@ -15,7 +15,7 @@ tags: [announcements]
 
 ## IMPORTANT ANNOUNCEMENT:
 
-The ETC Cooperative is changing the RPC URL for the Ethereum Classic mainnet from Etherecluster to Rivet.
+The ETC Cooperative is changing the RPC URL for the Ethereum Classic mainnet from Ethercluster to Rivet.
 
 This is important information for wallet operators, exchanges, mining pools, dapps or any other Ethereum Classic service or application who uses Ethercluster as an endpoint to send transactions and query the mainnet.
 


### PR DESCRIPTION
Fixing the typo.