### PR TITLE
Updated postal address

### DIFF
--- a/src/content/pages/contact/contact.mdx
+++ b/src/content/pages/contact/contact.mdx
@@ -31,9 +31,7 @@ How to stay in contact with the ETC Cooperative:
 - Discord
     - [ETC Cooperative Discord](https://discord.gg/5wDyd6u6pU)
     - [ETC Community Discord](https://ethereumclassic.org/discord)
-
-Snail mail:
-
+- Postal address:
     Ethereum Classic Cooperative Inc
     1207 Delaware Ave #541
     Wilmington, DE 19806

--- a/src/content/pages/contact/contact.mdx
+++ b/src/content/pages/contact/contact.mdx
@@ -31,7 +31,10 @@ How to stay in contact with the ETC Cooperative:
 - Discord
     - [ETC Cooperative Discord](https://discord.gg/5wDyd6u6pU)
     - [ETC Community Discord](https://ethereumclassic.org/discord)
-- Postal address:
+
+------
+Postal address:
+
     Ethereum Classic Cooperative Inc
     1207 Delaware Ave #541
     Wilmington, DE 19806

--- a/src/content/pages/contact/contact.mdx
+++ b/src/content/pages/contact/contact.mdx
@@ -16,7 +16,7 @@ How to stay in contact with the ETC Cooperative:
     - Donald McIntyre, Senior Editor: donald@etccooperative.org
     - Andrew Dick, Marketing Manager: andrew@etccooperative.org
     - Angelah Liu, Communications Manager: angelah@etccooperative.org
-    - Emma Todd, Events, Manager: emma@etccooperative.org
+    - Emma Todd, Events Manager: emma@etccooperative.org
 - Twitter
     - [@ETCCooperative](https://twitter.com/ETCCooperative) - ETC Cooperative
     - [@bobsummerwill](https://twitter.com/bobsummerwill) - Bob Summerwill
@@ -31,3 +31,10 @@ How to stay in contact with the ETC Cooperative:
 - Discord
     - [ETC Cooperative Discord](https://discord.gg/5wDyd6u6pU)
     - [ETC Community Discord](https://ethereumclassic.org/discord)
+
+Snail mail:
+
+    Ethereum Classic Cooperative Inc
+    1207 Delaware Ave #541
+    Wilmington, DE 19806
+    USA


### PR DESCRIPTION
We now have a mail forwarding service and are no longer using the DCG address in NY.
Bob has never been to that address and has never received mail from there.
It was used at the start because Grayscale did the paperwork to create the Coop legal entity.
Anthony and Yaz were donated some office space there which they used occasionally.
That was all many years ago.